### PR TITLE
update to hyper 0.10, serde 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ license = "Apache-2.0"
 
 [dependencies]
 hyper = "0.10"
-serde = "0.9"
-serde_derive = "0.9"
-serde_json = "0.9"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
 
 [dependencies.chrono]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-hyper = "0.9"
+hyper = "0.10"
 serde = "0.9"
 serde_derive = "0.9"
 serde_json = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub fn get_category(id: u64) -> Result<Category, String> {
     }
 }
 
-fn parse_response<T>(resp: &str) -> Result<T, String> where T: serde::de::Deserialize {
+fn parse_response<T>(resp: &str) -> Result<T, String> where T: serde::de::DeserializeOwned {
     match serde_json::from_str(&resp) {
         Ok(t) => { Ok(t) }
         Err(e) => { Err(format!("{:?}", e)) }


### PR DESCRIPTION
I'd like to update this because `hyper@0.9` depends on a version of `openssl` which does not support my system's version of OpenSSL (1.1.0e).